### PR TITLE
added somewhat working cache

### DIFF
--- a/backend/app/cache/audio_cache.py
+++ b/backend/app/cache/audio_cache.py
@@ -1,39 +1,26 @@
 import datetime
-import subprocess
 import time
 import yt_dlp
 
-from models.results_models import AudioInfo
-from services.youtube_service import format_duration
+from models.results_models import AudioUrlAndInfo, AudioInfo
+from services.format_service import format_duration
 
 #variable for in-memory cache
-audio_url_cache = {}
+cached_info: dict[str, AudioInfo] = {}
 
 #cache for 6hrs max as yt-dlp link expires in 6 hrs
 CACHE_DURATION = 6*3600
 
-def is_valid(entry):
-    return time.time() < entry["expires_at"]
+def is_valid(entry: AudioInfo) -> bool:
+    return time.time() < entry.expires_at
 
-def get_cached_audio_url(video_id):
-    entry = audio_url_cache.get(video_id)
+def get_cached_audio_info(video_id: str) -> AudioUrlAndInfo | None:
+    entry = cached_info.get(video_id)
     if entry and is_valid(entry):
-        return entry["audio_url"]
+        return AudioUrlAndInfo(video_id=entry)
     return None
 
 def extract_audio_url_and_info(video_id):
-    url = subprocess.check_output([
-        "yt-dlp", "-f", "bestaudio", "--get-url",
-        f"https://youtube.com/watch?v={video_id}"
-    ]).decode().strip()
-    
-    audio_url_cache[video_id] = {
-        "audio_url": url,
-        "expires_at": time.time() + CACHE_DURATION
-    }
-    return url
-
-def get_video_info(video_id: str) -> AudioInfo:
     ydl_opts = {
         'quiet': True,
         'format': '140',
@@ -44,16 +31,19 @@ def get_video_info(video_id: str) -> AudioInfo:
     
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         info = ydl.extract_info(f"https://youtu.be/{video_id}", download=False)
-        
         duration_seconds = info.get('duration', 0)
         formatted_duration = format_duration(datetime.timedelta(seconds=duration_seconds))
-        
-        return AudioInfo(
-            url=info['url'],
-            title=info.get('title', ''),
-            duration=formatted_duration,
-            format='m4a',
-            quality='128kbps',
-            thumbnail=info.get('thumbnail', ''),
-        )
-        
+    
+    audio_info = AudioInfo(
+        url=info['url'],
+        title=info.get('title', ''),
+        thumbnail=info.get('thumbnail', ''),
+        channel=info.get('channel', 'Unknown Channel'),
+        expires_at=time.time() + CACHE_DURATION,
+        duration= formatted_duration,
+        format= "m4a",
+        quality= '128kbps',
+    )
+    cached_info[video_id] = audio_info
+    
+    return AudioUrlAndInfo(video_id=audio_info)

--- a/backend/app/cache/audio_cache.py
+++ b/backend/app/cache/audio_cache.py
@@ -1,0 +1,59 @@
+import datetime
+import subprocess
+import time
+import yt_dlp
+
+from models.results_models import AudioInfo
+from services.youtube_service import format_duration
+
+#variable for in-memory cache
+audio_url_cache = {}
+
+#cache for 6hrs max as yt-dlp link expires in 6 hrs
+CACHE_DURATION = 6*3600
+
+def is_valid(entry):
+    return time.time() < entry["expires_at"]
+
+def get_cached_audio_url(video_id):
+    entry = audio_url_cache.get(video_id)
+    if entry and is_valid(entry):
+        return entry["audio_url"]
+    return None
+
+def extract_audio_url_and_info(video_id):
+    url = subprocess.check_output([
+        "yt-dlp", "-f", "bestaudio", "--get-url",
+        f"https://youtube.com/watch?v={video_id}"
+    ]).decode().strip()
+    
+    audio_url_cache[video_id] = {
+        "audio_url": url,
+        "expires_at": time.time() + CACHE_DURATION
+    }
+    return url
+
+def get_video_info(video_id: str) -> AudioInfo:
+    ydl_opts = {
+        'quiet': True,
+        'format': '140',
+        'noplaylist': True,
+        'socket_timeout': 5,
+        'retries': 0,
+    }
+    
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(f"https://youtu.be/{video_id}", download=False)
+        
+        duration_seconds = info.get('duration', 0)
+        formatted_duration = format_duration(datetime.timedelta(seconds=duration_seconds))
+        
+        return AudioInfo(
+            url=info['url'],
+            title=info.get('title', ''),
+            duration=formatted_duration,
+            format='m4a',
+            quality='128kbps',
+            thumbnail=info.get('thumbnail', ''),
+        )
+        

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,6 +32,7 @@ app.add_middleware(
 async def root():
     return {"message": "SanBeats API"}
 
+
 app.include_router(youtube.router,prefix="/api", tags=["Youtube API"])
 app.include_router(authenticated_youtube.router,prefix="/api", tags=["Logged in Youtube API"])
 app.include_router(auth_service.router, tags=["Google Login"])

--- a/backend/app/models/results_models.py
+++ b/backend/app/models/results_models.py
@@ -7,7 +7,7 @@ class SearchResult(BaseModel):
     duration: str
     thumbnail: str
     channel: str
-
+    
 class AudioInfo(BaseModel):
     url: str
     title: str
@@ -15,6 +15,8 @@ class AudioInfo(BaseModel):
     format: str
     quality: str
     thumbnail: str
+    channel: str
+    expires_at: float
     
-class AudioUrl(BaseModel):
-    url: str
+class AudioUrlAndInfo(BaseModel):
+    video_id: AudioInfo

--- a/backend/app/models/results_models.py
+++ b/backend/app/models/results_models.py
@@ -15,3 +15,6 @@ class AudioInfo(BaseModel):
     format: str
     quality: str
     thumbnail: str
+    
+class AudioUrl(BaseModel):
+    url: str

--- a/backend/app/routes/youtube.py
+++ b/backend/app/routes/youtube.py
@@ -1,7 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 import logging
 from fastapi import APIRouter, HTTPException, Query, logger
-from models import SearchResult, AudioInfo
+from models import SearchResult, AudioInfo, AudioUrl
 from typing import List
 import asyncio
 from services.youtube_service import(
@@ -10,6 +10,7 @@ from services.youtube_service import(
     get_trending_music,
     get_video_info,
     get_search_result,
+    get_audio
 )
 
 router = APIRouter()
@@ -45,6 +46,18 @@ async def get_audio_url_and_info(video_id: str):
             executor, get_video_info, video_id
         )
         return info
+    
+    except Exception as e:
+        logger.error(f"Stream Info error {str(e)}")
+        
+#GET METHOD FOR GETTING YOUTUBE AUDIO URL
+@router.get("/audio/{video_id}", response_model=AudioUrl)
+async def get_audio_url_and_info(video_id: str):
+    try:
+        audio_url = await asyncio.get_event_loop().run_in_executor(
+            executor, get_audio, video_id
+        )
+        return audio_url
     
     except Exception as e:
         logger.error(f"Stream Info error {str(e)}")

--- a/backend/app/routes/youtube.py
+++ b/backend/app/routes/youtube.py
@@ -1,16 +1,15 @@
 from concurrent.futures import ThreadPoolExecutor
 import logging
 from fastapi import APIRouter, HTTPException, Query, logger
-from models import SearchResult, AudioInfo, AudioUrl
+from models import SearchResult, AudioInfo, AudioUrlAndInfo
 from typing import List
 import asyncio
 from services.youtube_service import(
     get_most_viewed_music,
     get_similar_videos,
     get_trending_music,
-    get_video_info,
     get_search_result,
-    get_audio
+    get_audio_info
 )
 
 router = APIRouter()
@@ -37,27 +36,15 @@ async def search_youtube(
         logger.error(f"Search error: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Search failed {str(e)}")
 
-
-#GET METHOD FOR GETTING YOUTUBE AUDIO URL
-@router.get("/info/{video_id}", response_model=AudioInfo)
-async def get_audio_url_and_info(video_id: str):
-    try:
-        info = await asyncio.get_event_loop().run_in_executor(
-            executor, get_video_info, video_id
-        )
-        return info
-    
-    except Exception as e:
-        logger.error(f"Stream Info error {str(e)}")
         
 #GET METHOD FOR GETTING YOUTUBE AUDIO URL
-@router.get("/audio/{video_id}", response_model=AudioUrl)
+@router.get("/info/{video_id}", response_model=AudioUrlAndInfo)
 async def get_audio_url_and_info(video_id: str):
     try:
-        audio_url = await asyncio.get_event_loop().run_in_executor(
-            executor, get_audio, video_id
+        audio_info = await asyncio.get_event_loop().run_in_executor(
+            executor, get_audio_info, video_id
         )
-        return audio_url
+        return audio_info
     
     except Exception as e:
         logger.error(f"Stream Info error {str(e)}")

--- a/backend/app/services/format_service.py
+++ b/backend/app/services/format_service.py
@@ -1,0 +1,11 @@
+#function for parsing time
+import datetime
+
+def format_duration(td: datetime.timedelta) -> str:
+    total_seconds = int(td.total_seconds())
+    minutes, seconds = divmod(total_seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}:{minutes:02}:{seconds:02}"
+    else:
+        return f"{minutes}:{seconds:02}"

--- a/backend/app/services/youtube_service.py
+++ b/backend/app/services/youtube_service.py
@@ -4,7 +4,7 @@ import os
 import logging
 import yt_dlp
 from fastapi import HTTPException
-from models import SearchResult, AudioInfo
+from models import SearchResult, AudioInfo, AudioUrl
 from isodate import parse_duration
 from typing import List
 
@@ -78,6 +78,18 @@ def list_videos(data: dict) -> List[SearchResult]:
         ))     
         
     return results
+
+from cache.audio_cache import get_cached_audio_url, extract_audio_url
+#funciton for getting audio url
+def get_audio(video_id: str) -> AudioUrl:
+    cached = get_cached_audio_url(video_id)
+    if cached:
+        return {"url": cached}
+    try:
+        audio_url = extract_audio_url(video_id)
+        return {"url": audio_url}
+    except Exception as e:
+        logger.error(f"Error while gettting audio url {str(e)}")
 
 #funciton for getting video info from youtube and using yt-dlp to return audio only url 
 def get_video_info(video_id: str) -> AudioInfo:

--- a/backend/app/services/youtube_service.py
+++ b/backend/app/services/youtube_service.py
@@ -1,12 +1,14 @@
-import datetime
 import requests
 import os
 import logging
-import yt_dlp
+
 from fastapi import HTTPException
-from models import SearchResult, AudioInfo, AudioUrl
 from isodate import parse_duration
 from typing import List
+
+from services.format_service import format_duration
+from cache.audio_cache import get_cached_audio_info, extract_audio_url_and_info
+from models import SearchResult, AudioInfo, AudioUrlAndInfo
 
 #Get api key from .env
 YOUTUBE_API_KEY = os.getenv("YOUTUBE_API_KEY")
@@ -79,42 +81,18 @@ def list_videos(data: dict) -> List[SearchResult]:
         
     return results
 
-from cache.audio_cache import get_cached_audio_url, extract_audio_url
 #funciton for getting audio url
-def get_audio(video_id: str) -> AudioUrl:
-    cached = get_cached_audio_url(video_id)
+def get_audio_info(video_id: str) -> AudioUrlAndInfo:
+    cached = get_cached_audio_info(video_id)
     if cached:
-        return {"url": cached}
+        return cached
     try:
-        audio_url = extract_audio_url(video_id)
-        return {"url": audio_url}
-    except Exception as e:
-        logger.error(f"Error while gettting audio url {str(e)}")
+        return extract_audio_url_and_info(video_id)
 
-#funciton for getting video info from youtube and using yt-dlp to return audio only url 
-def get_video_info(video_id: str) -> AudioInfo:
-    ydl_opts = {
-        'quiet': True,
-        'format': '140',
-        'noplaylist': True,
-        'socket_timeout': 5,
-        'retries': 0,
-    }
-    
-    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-        info = ydl.extract_info(f"https://youtu.be/{video_id}", download=False)
-        
-        duration_seconds = info.get('duration', 0)
-        formatted_duration = format_duration(datetime.timedelta(seconds=duration_seconds))
-        
-        return AudioInfo(
-            url=info['url'],
-            title=info.get('title', ''),
-            duration=formatted_duration,
-            format='m4a',
-            quality='128kbps',
-            thumbnail=info.get('thumbnail', ''),
-        )
+    except Exception as e:
+        logger.error(f"Error while gettting audio info {str(e)}")
+        raise
+
         
 #function forsearchiing in youtube
 def get_search_result(q: str) -> List[SearchResult]:
@@ -261,13 +239,3 @@ def get_most_viewed_music() -> List[SearchResult]:
     
     except Exception as e:
         logger.error(f"Most Viewed music error {str(e)}")
-
-#function for parsing time
-def format_duration(td: datetime.timedelta) -> str:
-    total_seconds = int(td.total_seconds())
-    minutes, seconds = divmod(total_seconds, 60)
-    hours, minutes = divmod(minutes, 60)
-    if hours:
-        return f"{hours}:{minutes:02}:{seconds:02}"
-    else:
-        return f"{minutes}:{seconds:02}"


### PR DESCRIPTION
## Summary by Sourcery

Integrate an in-memory cache for audio URL and metadata retrieval, refactor formatting into a shared service, and adapt models and endpoints to use the new AudioUrlAndInfo schema for efficient audio info delivery.

New Features:
- Add in-memory caching for YouTube audio info with a 6-hour TTL through a new audio_cache module
- Introduce a new AudioUrlAndInfo schema and update the /info endpoint to return cached audio info

Enhancements:
- Refactor audio extraction logic into a cache-aware get_audio_info service that delegates to extract_audio_url_and_info
- Move duration formatting into a dedicated format_service
- Update models and route handlers to support the new AudioUrlAndInfo type and caching workflow